### PR TITLE
Add GitHub Copilot LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ OLLAMA_BASE_URL=http://localhost:11434
 LM_STUDIO_BASE_URL=http://localhost:8000
 
 # GitHub API
+# Personal access token for GitHub Models/Copilot
 GITHUB_API_TOKEN=your-github-personal-access-token
 
 # Frontend

--- a/backend/app/llm/factory.py
+++ b/backend/app/llm/factory.py
@@ -8,6 +8,7 @@ from app.llm.openrouter_client import OpenRouterClient
 # Import newly added clients
 from app.llm.anthropic_client import AnthropicClient
 from app.llm.google_gemini_client import GoogleGeminiClient
+from app.llm.github_copilot_client import GitHubCopilotClient
 from app.core.config import settings
 
 # Set up logging
@@ -31,6 +32,7 @@ class LLMFactory:
         "anthropic": AnthropicClient, # Use the actual Anthropic client
         "openrouter": OpenRouterClient,
         "google_gemini": GoogleGeminiClient, # Add Google Gemini client
+        "github_copilot": GitHubCopilotClient,
         # "deepseek": DeepseekClient,
         # "lmstudio": LMStudioClient,
     }
@@ -226,6 +228,8 @@ class LLMFactory:
             return "openai/gpt-3.5-turbo"
         elif provider == "google_gemini":
             return "gemini-pro" # Default for Google Gemini
+        elif provider == "github_copilot":
+            return "openai/gpt-4.1"
         # elif provider == "deepseek":
         #     return "deepseek-chat"
         # elif provider == "lmstudio":
@@ -279,6 +283,14 @@ class LLMFactory:
         providers["google_gemini"] = {
             "available": bool(settings.GOOGLE_GEMINI_API_KEY),
             "default_model": cls._get_default_model("google_gemini"), # Use the method
+            "requires_api_key": True,
+            "requires_base_url": False
+        }
+
+        # Check GitHub Copilot
+        providers["github_copilot"] = {
+            "available": bool(settings.GITHUB_API_TOKEN),
+            "default_model": cls._get_default_model("github_copilot"),
             "requires_api_key": True,
             "requires_base_url": False
         }

--- a/backend/app/llm/github_copilot_client.py
+++ b/backend/app/llm/github_copilot_client.py
@@ -85,10 +85,7 @@ class GitHubCopilotClient(LLMClient):
     ) -> AsyncGenerator[Dict[str, Any], None]:
         async with aiohttp.ClientSession() as session:
             async with session.post(url, headers=headers, json=payload) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    logger.error(f"GitHub API error: {error_text}")
-                    raise Exception(f"GitHub API error: {response.status} - {error_text}")
+                await self._handle_non_200_response(response)
                 content = ""
                 token_count = 0
                 async for line in response.content:

--- a/backend/app/llm/github_copilot_client.py
+++ b/backend/app/llm/github_copilot_client.py
@@ -1,0 +1,135 @@
+import aiohttp
+import json
+import time
+import logging
+import asyncio
+from typing import List, Dict, Any, Optional, Union, AsyncGenerator
+
+from app.llm.base import LLMClient
+from app.core.config import settings
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class GitHubCopilotClient(LLMClient):
+    """Client for GitHub Models (Copilot) API."""
+
+    def __init__(
+        self,
+        model: str = "openai/gpt-4.1",
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = "https://models.github.ai",
+        org: Optional[str] = None,
+        embedding_model: Optional[str] = None,
+    ):
+        super().__init__(model, api_key, base_url, embedding_model)
+        self.api_key = api_key or settings.GITHUB_API_TOKEN
+        if not self.api_key:
+            raise ValueError("GitHub API token is required")
+        self.org = org
+        if not self.base_url:
+            self.base_url = "https://models.github.ai"
+
+    def _build_url(self) -> str:
+        if self.org:
+            return f"{self.base_url}/orgs/{self.org}/inference/chat/completions"
+        return f"{self.base_url}/inference/chat/completions"
+
+    async def generate(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.7,
+        max_tokens: Optional[int] = None,
+        stream: bool = False,
+    ) -> Union[Dict[str, Any], AsyncGenerator[Dict[str, Any], None]]:
+        url = self._build_url()
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/vnd.github+json",
+        }
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "stream": stream,
+        }
+        if max_tokens:
+            payload["max_tokens"] = max_tokens
+        start_time = time.time()
+        if stream:
+            return self._stream_response(url, headers, payload, start_time)
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=payload) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(f"GitHub API error: {error_text}")
+                    raise Exception(f"GitHub API error: {response.status} - {error_text}")
+                result = await response.json()
+                tokens = result.get("usage", {}).get("completion_tokens", 0)
+                tokens_per_second = self.calculate_tokens_per_second(start_time, tokens)
+                return {
+                    "content": result["choices"][0]["message"]["content"],
+                    "model": self.model,
+                    "provider": "github_copilot",
+                    "tokens": tokens,
+                    "tokens_per_second": tokens_per_second,
+                }
+
+    async def _stream_response(
+        self,
+        url: str,
+        headers: Dict[str, str],
+        payload: Dict[str, Any],
+        start_time: float,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=payload) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(f"GitHub API error: {error_text}")
+                    raise Exception(f"GitHub API error: {response.status} - {error_text}")
+                content = ""
+                token_count = 0
+                async for line in response.content:
+                    line = line.decode("utf-8").strip()
+                    if not line or line == "data: [DONE]":
+                        if line == "data: [DONE]":
+                            break
+                        continue
+                    if line.startswith("data: "):
+                        line = line[6:]
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        logger.warning(f"Could not parse line: {line}")
+                        continue
+                    delta = data.get("choices", [{}])[0].get("delta", {})
+                    delta_content = delta.get("content", "")
+                    if delta_content:
+                        content += delta_content
+                        token_count += 1
+                        tokens_per_second = self.calculate_tokens_per_second(start_time, token_count)
+                        yield {
+                            "content": content,
+                            "model": self.model,
+                            "provider": "github_copilot",
+                            "tokens": token_count,
+                            "tokens_per_second": tokens_per_second,
+                            "done": False,
+                            "timestamp": time.time(),
+                        }
+                        await asyncio.sleep(0)
+                tokens_per_second = self.calculate_tokens_per_second(start_time, token_count)
+                yield {
+                    "content": content,
+                    "model": self.model,
+                    "provider": "github_copilot",
+                    "tokens": token_count,
+                    "tokens_per_second": tokens_per_second,
+                    "done": True,
+                }
+
+    async def get_embeddings(self, texts: List[str]) -> List[List[float]]:
+        logger.warning("GitHub Copilot client does not support embeddings directly.")
+        raise NotImplementedError("GitHub Copilot embeddings are not supported")


### PR DESCRIPTION
This pull request introduces support for GitHub Copilot as a new provider in the LLM factory. The changes include adding a new client class for GitHub Copilot, updating the factory to integrate the new provider, and adding configuration options for the API token.

### Integration of GitHub Copilot:

* **New GitHub Copilot Client**: Added `GitHubCopilotClient` class in `backend/app/llm/github_copilot_client.py`, which implements methods for generating responses and streaming results from the GitHub Copilot API. It includes support for authentication, error handling, and token usage tracking.

* **Provider Registration**: Updated the `LLMFactory` class in `backend/app/llm/factory.py` to register GitHub Copilot as a provider. This includes adding it to the `_clients` dictionary, specifying its default model (`openai/gpt-4.1`), and checking its availability based on the presence of a GitHub API token. [[1]](diffhunk://#diff-dc0bd124d216e1311c5fea733f20e132089457d9f45d7880aab1ba8f9a661809R11) [[2]](diffhunk://#diff-dc0bd124d216e1311c5fea733f20e132089457d9f45d7880aab1ba8f9a661809R35) [[3]](diffhunk://#diff-dc0bd124d216e1311c5fea733f20e132089457d9f45d7880aab1ba8f9a661809R231-R232) [[4]](diffhunk://#diff-dc0bd124d216e1311c5fea733f20e132089457d9f45d7880aab1ba8f9a661809R290-R297)

### Configuration:

* **Environment Variable**: Added a placeholder for `GITHUB_API_TOKEN` in `.env.example` to allow users to configure their GitHub API token for authentication.